### PR TITLE
Adding epsgCode on wktParams.

### DIFF
--- a/src/Wkt.php
+++ b/src/Wkt.php
@@ -317,6 +317,18 @@ class Wkt {
 		default:
 			break;
 		}
+		
+		if(!isset($wktParams->epsgCode)) {
+			
+			foreach ($wktArray as $item) {
+				$auth=strpos($item, "AUTHORITY");
+				if($auth===0) {
+					$wktSectionsFirstLevel = self::ParseWKTIntoSections($item);
+					$wktParams->epsgCode = $wktSectionsFirstLevel[1].":".str_replace('"', '', $wktSectionsFirstLevel[2][0]);
+					break;
+				}
+			}
+		}
 
 		foreach ($wktArray as $wktArrayContent) {
 


### PR DESCRIPTION
Included additional member, epsgCode, on wktParams. This change has allowed make a method to translate the WKT projection for the EPSG code.

``` php
    /**
     * Translate the WKT projection to EPSG code
     * @param string $wkt, the WKT projection format.
     * Ex.:http://spatialreference.org/ref/sr-org/upload-test-via-ogc-wkt/ogcwkt/
     * @return string, the EPSG code or false in failure.
     */
    public function epsgFromWKT($wkt) {
        // Initialise Proj4
        $proj4 = new Proj4php();
        $projOSGB36 = new Proj($wkt, $proj4);
        if(isset($projOSGB36->epsgCode)) {
            return $projOSGB36->epsgCode;
        }else {
            return false;
        }
    }
```
